### PR TITLE
修改了Builder类的Product指针为Product

### DIFF
--- a/code/Builder/Builder.cpp
+++ b/code/Builder/Builder.cpp
@@ -38,5 +38,5 @@ void Builder::buildPartC(){
 
 
 Product* Builder::getResult(){
-	return m_prod;
+	return &m_prod;
 }

--- a/code/Builder/Builder.h
+++ b/code/Builder/Builder.h
@@ -21,6 +21,6 @@ public:
 	virtual void buildPartC();
 	virtual Product * getResult();
 protected :
-	Product * m_prod;
+	Product  m_prod;
 };
 #endif // !defined(EA_938F1725_29F0_4174_93A3_D49DAB5D16A0__INCLUDED_)

--- a/code/Builder/ConcreteBuilder.cpp
+++ b/code/Builder/ConcreteBuilder.cpp
@@ -19,15 +19,15 @@ ConcreteBuilder::~ConcreteBuilder(){
 }
 
 void ConcreteBuilder::buildPartA(){
-	m_prod->setA("A Style "); //不同的建造者，可以实现不同产品的建造  
+	m_prod.setA("A Style "); //不同的建造者，可以实现不同产品的建造  
 }
 
 
 void ConcreteBuilder::buildPartB(){
-	m_prod->setB("B Style ");
+	m_prod.setB("B Style ");
 }
 
 
 void ConcreteBuilder::buildPartC(){
-	m_prod->setC("C style ");
+	m_prod.setC("C style ");
 }


### PR DESCRIPTION
Builder.h里的producted成员使用指针的话，默认初始化是nullptr，导致在ConcreteBuilder.cpp里使用指针调用Product类的成员出现错误。