### PR TITLE
修改“UML建模之时序图”的链接

### DIFF
--- a/read_uml.rst
+++ b/read_uml.rst
@@ -122,7 +122,7 @@ B不知道A；
 
 关于时序图，以下这篇文章将概念介绍的比较详细；更多实例应用，参见后续章节模式中的时序图；
 
-http://smartlife.blog.51cto.com/1146871/284874
+http://www.uml.org.cn/oobject/201009081.asp
 
 
 附录


### PR DESCRIPTION
因为原文章已经被51cto给删除了，现在找了另外一个转发那篇文章的链接。