### PR TITLE
修复单例模式的错误以及rst文件缺少.h示例代码

### DIFF
--- a/code/Singleton/Singleton.cpp
+++ b/code/Singleton/Singleton.cpp
@@ -14,10 +14,6 @@ Singleton::Singleton(){
 
 }
 
-Singleton::~Singleton(){
-	delete instance;
-}
-
 Singleton* Singleton::getInstance(){
 	if (instance == NULL)
 	{

--- a/code/Singleton/Singleton.h
+++ b/code/Singleton/Singleton.h
@@ -12,7 +12,6 @@ class Singleton
 {
 
 public:
-	virtual ~Singleton();
 	Singleton *m_Singleton;
 
 	static Singleton* getInstance();

--- a/creational_patterns/singleton.rst
+++ b/creational_patterns/singleton.rst
@@ -41,6 +41,11 @@
    :linenos:
    :emphasize-lines: 7-8
 
+.. literalinclude:: /code/Singleton/Singleton.h
+   :language: cpp
+   :linenos:
+   :emphasize-lines: 21-28
+
 .. literalinclude:: /code/Singleton/Singleton.cpp
    :language: cpp
    :linenos:


### PR DESCRIPTION
+ 单例模式中的析构函数可默认生成，且不用声明为virtual，同时，在析构函数里，delete自己，会造成不断调用析构 - delete死循环。
+ rst文件中，缺少`Singleton.h`文件的代码